### PR TITLE
[FIX#19] : 바텀내비게이션 클릭시 badge 초기화 안되는 오류 해결

### DIFF
--- a/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
@@ -23,10 +23,9 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     }
 
     private fun removeBadgeOnNotification(navController: NavController) {
-        val badgeDrawable = binding.bnvMain.getBadge(R.id.fragment_notification)
         navController.addOnDestinationChangedListener { _, destination, _ ->
             if (destination.id == R.id.fragment_notification) {
-                badgeDrawable?.apply {
+                binding.bnvMain.getBadge(R.id.fragment_notification)?.apply {
                     isVisible = false
                     clearNumber() // or badgeDrawable?.clearText()
                 }


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #19 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 바텀내비 알림 탭 클릭시 badge가 사라지지 않는 오류를 수정했습니다
- 

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
getBadge() 함수가 각 메뉴의 아이디에 연결된 뱃지를 가져오는 거라 알림탭 에 갈때마다 badgeDrawable을 부르는 형식으로 해야 badge가 지워질 것 같습니다.

기존 코드는 최초 초기화 한 이후에도 계속해서 같은 위치를 참조 하는 것 같아 수정했습니다!