### PR TITLE
[Feature/#67] my page auth info ui 구현

### DIFF
--- a/domain/src/main/java/com/teamdontbe/domain/entity/AuthInfoEntity.kt
+++ b/domain/src/main/java/com/teamdontbe/domain/entity/AuthInfoEntity.kt
@@ -1,0 +1,9 @@
+package com.teamdontbe.domain.entity
+
+data class AuthInfoEntity(
+    val memberId: Int,
+    val joinDate: String,
+    val showMemberId: String,
+    val socialPlatform: String,
+    val versionInformation: String,
+)

--- a/feature/src/main/java/com/teamdontbe/feature/mypage/MyPageAuthInfoFragment.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/mypage/MyPageAuthInfoFragment.kt
@@ -1,0 +1,38 @@
+package com.teamdontbe.feature.mypage
+
+import android.graphics.Paint
+import androidx.fragment.app.viewModels
+import com.teamdontbe.core_ui.base.BindingFragment
+import com.teamdontbe.core_ui.util.context.toast
+import com.teamdontbe.feature.R
+import com.teamdontbe.feature.databinding.FragmentMyPageAuthInfoBinding
+
+class MyPageAuthInfoFragment :
+    BindingFragment<FragmentMyPageAuthInfoBinding>(R.layout.fragment_my_page_auth_info) {
+    private val viewModel: MyPageAuthInfoViewModel by viewModels()
+
+    override fun initView() {
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
+
+        binding.tvMyPageAuthInfoConditionsContent.paintFlags = Paint.UNDERLINE_TEXT_FLAG
+        binding.tvMyPageAuthInfoWithdrawContent.paintFlags = Paint.UNDERLINE_TEXT_FLAG
+
+        initConditionsBtnClickListener()
+        initWithdrawBtnClickListener()
+    }
+
+    private fun initWithdrawBtnClickListener() {
+        binding.tvMyPageAuthInfoWithdrawContent.setOnClickListener {
+            // 테스트용 코드
+            context?.toast("회원탈퇴 클릭됨")
+        }
+    }
+
+    private fun initConditionsBtnClickListener() {
+        binding.tvMyPageAuthInfoConditionsContent.setOnClickListener {
+            // 테스트용 코드
+            context?.toast("자세히보기 클릭됨")
+        }
+    }
+}

--- a/feature/src/main/java/com/teamdontbe/feature/mypage/MyPageAuthInfoViewModel.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/mypage/MyPageAuthInfoViewModel.kt
@@ -1,0 +1,17 @@
+package com.teamdontbe.feature.mypage
+
+import androidx.lifecycle.ViewModel
+import com.teamdontbe.domain.entity.AuthInfoEntity
+
+class MyPageAuthInfoViewModel : ViewModel() {
+    val mockDataList =
+        listOf(
+            AuthInfoEntity(
+                1,
+                "2023.12.30",
+                "example",
+                "카카오톡 소셜 로그인",
+                "V.1.0.01",
+            ),
+        )
+}

--- a/feature/src/main/res/drawable/ic_circle_back_none_background.xml
+++ b/feature/src/main/res/drawable/ic_circle_back_none_background.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="31dp"
+    android:height="28dp"
+    android:viewportWidth="31"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M14.8,8L8.8,14L14.8,20"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#49494C"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20.8,15C21.352,15 21.8,14.552 21.8,14C21.8,13.448 21.352,13 20.8,13V15ZM9.8,15H20.8V13H9.8V15Z"
+      android:fillColor="#49494C"/>
+</vector>

--- a/feature/src/main/res/layout/fragment_my_page_auth_info.xml
+++ b/feature/src/main/res/layout/fragment_my_page_auth_info.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.teamdontbe.feature.mypage.MyPageAuthInfoViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar_my_page_auth_info"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:minHeight="0dp"
+                app:contentInsetStart="0dp"
+                app:layout_scrollFlags="scroll|enterAlways">
+
+                <ImageView
+                    android:id="@+id/iv_my_page_auth_info_back"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:src="@drawable/ic_circle_back_none_background" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="계정 정보"
+                    android:textAppearance="@style/TextAppearance.DontBe.body_semi_16" />
+            </androidx.appcompat.widget.Toolbar>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/gray_2" />
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_social_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="14dp"
+            android:text="소셜 로그인"
+            android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/appbar_my_page_auth_info" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_social_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:text="@{viewModel.mockDataList[0].socialPlatform}"
+            android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
+            android:textColor="@color/gray_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_auth_info_social_title"
+            tools:text="테스트" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_version_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="27dp"
+            android:text="버전 정보"
+            android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_social_title" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_version_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:text="@{viewModel.mockDataList[0].versionInformation}"
+            android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
+            android:textColor="@color/gray_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_auth_info_version_title"
+            tools:text="테스트" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_id_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="27dp"
+            android:text="아이디"
+            android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_version_title" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_id_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:text="@{viewModel.mockDataList[0].showMemberId}"
+            android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
+            android:textColor="@color/gray_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_auth_info_id_title"
+            tools:text="테스트" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_date_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="27dp"
+            android:text="가입일"
+            android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_id_title" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_date_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:text="@{viewModel.mockDataList[0].joinDate}"
+            android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
+            android:textColor="@color/gray_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_auth_info_date_title"
+            tools:text="테스트" />
+
+        <View
+            android:id="@+id/view_my_page_auth_info_line"
+            android:layout_width="match_parent"
+            android:layout_height="8dp"
+            android:layout_marginTop="13dp"
+            android:background="@color/gray_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_date_title" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_conditions_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="14dp"
+            android:text="이용약관"
+            android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_my_page_auth_info_line" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_conditions_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:text="자세히보기"
+            android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
+            android:textColor="@color/gray_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_auth_info_conditions_title" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_withdraw_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="27dp"
+            android:clickable="true"
+            android:text="아쉬워요, 돈비를 떠나시겠어요?"
+            android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_conditions_title" />
+
+        <TextView
+            android:id="@+id/tv_my_page_auth_info_withdraw_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:clickable="true"
+            android:text="회원탈퇴"
+            android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
+            android:textColor="@color/gray_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_auth_info_withdraw_title" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/feature/src/main/res/layout/fragment_my_page_auth_info.xml
+++ b/feature/src/main/res/layout/fragment_my_page_auth_info.xml
@@ -41,7 +41,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="계정 정보"
+                    android:text="@string/my_page_auth_info_appbar"
                     android:textAppearance="@style/TextAppearance.DontBe.body_semi_16" />
             </androidx.appcompat.widget.Toolbar>
 
@@ -57,7 +57,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="14dp"
-            android:text="소셜 로그인"
+            android:text="@string/my_page_auth_info_social"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/appbar_my_page_auth_info" />
@@ -80,7 +80,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="27dp"
-            android:text="버전 정보"
+            android:text="@string/my_page_auth_info_version"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_social_title" />
@@ -103,7 +103,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="27dp"
-            android:text="아이디"
+            android:text="@string/my_page_auth_info_id"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_version_title" />
@@ -126,7 +126,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="27dp"
-            android:text="가입일"
+            android:text="@string/my_page_auth_info_date"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_id_title" />
@@ -159,7 +159,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="14dp"
-            android:text="이용약관"
+            android:text="@string/my_page_auth_info_conditions_title"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_my_page_auth_info_line" />
@@ -169,7 +169,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="15dp"
-            android:text="자세히보기"
+            android:text="@string/my_page_auth_info_conditions_content"
             android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
             android:textColor="@color/gray_7"
             app:layout_constraintEnd_toEndOf="parent"
@@ -182,7 +182,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="27dp"
             android:clickable="true"
-            android:text="아쉬워요, 돈비를 떠나시겠어요?"
+            android:text="@string/my_page_auth_info_withdraw_title"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_auth_info_conditions_title" />
@@ -193,7 +193,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="15dp"
             android:clickable="true"
-            android:text="회원탈퇴"
+            android:text="@string/my_page_auth_info_withdraw_content"
             android:textAppearance="@style/TextAppearance.DontBe.body_regular_14"
             android:textColor="@color/gray_7"
             app:layout_constraintEnd_toEndOf="parent"

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -82,5 +82,15 @@
     <string name="my_page_no_feed_text">%s님, 아직 글을 작성하지 않았네요!\n왠지 텅 빈 게시글이 허전하게 느껴져요.</string>
     <string name="my_page_no_feed_first">첫 게시글 남기기</string>
     <string name="my_page_comment_not_yet">아직 작성한 답글이 없어요.</string>
+    <!-- 마이 페이지 계정 정보 화면 -->
+    <string name="my_page_auth_info_appbar">계정 정보</string>
+    <string name="my_page_auth_info_social">소셜 로그인</string>
+    <string name="my_page_auth_info_version">버전 정보</string>
+    <string name="my_page_auth_info_id">아이디</string>
+    <string name="my_page_auth_info_date">가입일</string>
+    <string name="my_page_auth_info_conditions_title">이용약관</string>
+    <string name="my_page_auth_info_conditions_content">자세히보기</string>
+    <string name="my_page_auth_info_withdraw_title">아쉬워요, 돈비를 떠나시겠어요?</string>
+    <string name="my_page_auth_info_withdraw_content">회원탈퇴</string>
 
 </resources>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #67

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- my page auth info view 구현

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<img width="383" alt="스크린샷 2024-01-14 오전 1 25 17" src="https://github.com/TeamDon-tBe/ANDROID/assets/85453429/d925b79b-018f-45ca-8376-209d5673b85e">

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- data binding까지 했으니 뒤로가기 연결과 해당 프래그먼트 연결은 알아서 하쇼 ㅋㅅㅋ(사실 한거 없긴 함)
- 덕분에 데바 연습 잘 먹고 갑니다..