### PR TITLE
[Feature/#107] 닉네임 중복체크 서버 통신

### DIFF
--- a/data-remote/src/main/java/com/teamdontbe/data_remote/api/LoginApiService.kt
+++ b/data-remote/src/main/java/com/teamdontbe/data_remote/api/LoginApiService.kt
@@ -4,17 +4,26 @@ import com.teamdontbe.data.dto.BaseResponse
 import com.teamdontbe.data.dto.request.RequestLoginDto
 import com.teamdontbe.data.dto.response.ResponseLoginDto
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface LoginApiService {
     companion object {
         const val API = "api"
         const val V1 = "v1"
         const val AUTH = "auth"
+        const val NICKNAME_VALIDATION = "nickname-validation"
+        const val NICKNAME = "nickname"
     }
 
     @POST("/$API/$V1/$AUTH")
     suspend fun postLogin(
         @Body requestLogin: RequestLoginDto,
     ): BaseResponse<ResponseLoginDto>
+
+    @GET("/$API/$V1/$NICKNAME_VALIDATION")
+    suspend fun nickNameDoubleCheck(
+        @Query(NICKNAME) nickname: String,
+    ): BaseResponse<Unit>
 }

--- a/data-remote/src/main/java/com/teamdontbe/data_remote/datasourceimpl/LoginDataSourceImpl.kt
+++ b/data-remote/src/main/java/com/teamdontbe/data_remote/datasourceimpl/LoginDataSourceImpl.kt
@@ -8,9 +8,13 @@ import com.teamdontbe.data_remote.api.LoginApiService
 import javax.inject.Inject
 
 class LoginDataSourceImpl
-    @Inject
-    constructor(
-        private val loginApiService: LoginApiService,
-    ) : LoginDataSource {
-        override suspend fun postLogin(requestLogin: RequestLoginDto): BaseResponse<ResponseLoginDto> = loginApiService.postLogin(requestLogin)
-    }
+@Inject
+constructor(
+    private val loginApiService: LoginApiService,
+) : LoginDataSource {
+    override suspend fun postLogin(requestLogin: RequestLoginDto): BaseResponse<ResponseLoginDto> =
+        loginApiService.postLogin(requestLogin)
+
+    override suspend fun getNickNameDoubleCheck(nickname: String): BaseResponse<Unit> =
+        loginApiService.nickNameDoubleCheck(nickname)
+}

--- a/data/src/main/java/com/teamdontbe/data/datasource/LoginDataSource.kt
+++ b/data/src/main/java/com/teamdontbe/data/datasource/LoginDataSource.kt
@@ -6,4 +6,6 @@ import com.teamdontbe.data.dto.response.ResponseLoginDto
 
 interface LoginDataSource {
     suspend fun postLogin(requestLogin: RequestLoginDto): BaseResponse<ResponseLoginDto>
+
+    suspend fun getNickNameDoubleCheck(nickname: String): BaseResponse<Unit>
 }

--- a/data/src/main/java/com/teamdontbe/data/repositoryimpl/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/teamdontbe/data/repositoryimpl/LoginRepositoryImpl.kt
@@ -10,19 +10,29 @@ import timber.log.Timber
 import javax.inject.Inject
 
 class LoginRepositoryImpl
-    @Inject
-    constructor(
-        private val loginDataSource: LoginDataSource,
-    ) : LoginRepository {
-        override suspend fun postLogin(socialType: String): Flow<LoginEntity?> {
-            return flow {
-                val result =
-                    runCatching {
-                        loginDataSource.postLogin(RequestLoginDto(socialType)).data?.toLoginDataEntity()
-                    }
+@Inject
+constructor(
+    private val loginDataSource: LoginDataSource,
+) : LoginRepository {
+    override suspend fun postLogin(socialType: String): Flow<LoginEntity?> {
+        return flow {
+            val result =
+                runCatching {
+                    loginDataSource.postLogin(RequestLoginDto(socialType)).data?.toLoginDataEntity()
+                }
 
-                Timber.d(result.toString())
-                emit(result.getOrDefault(LoginEntity("", -1, "", "", false)))
-            }
+            Timber.d(result.toString())
+            emit(result.getOrDefault(LoginEntity("", -1, "", "", false)))
         }
     }
+
+    override suspend fun getNickNameDoubleCheck(nickName: String): Flow<String> {
+        return flow {
+            val result =
+                runCatching {
+                    loginDataSource.getNickNameDoubleCheck(nickName).message
+                }
+            emit(result.getOrDefault(""))
+        }
+    }
+}

--- a/domain/src/main/java/com/teamdontbe/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/teamdontbe/domain/repository/LoginRepository.kt
@@ -5,4 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface LoginRepository {
     suspend fun postLogin(requestLogin: String): Flow<LoginEntity?>
+
+    suspend fun getNickNameDoubleCheck(nickName: String): Flow<String>
 }

--- a/feature/src/main/java/com/teamdontbe/feature/signup/SignUpProfileActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/signup/SignUpProfileActivity.kt
@@ -1,12 +1,17 @@
 package com.teamdontbe.feature.signup
 
 import androidx.activity.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.teamdontbe.core_ui.base.BindingActivity
 import com.teamdontbe.core_ui.util.context.colorOf
+import com.teamdontbe.core_ui.view.UiState
 import com.teamdontbe.feature.R
 import com.teamdontbe.feature.databinding.ActivitySignUpProfileBinding
 import com.teamdontbe.feature.mypage.bottomsheet.MyPageBottomSheet.Companion.MY_PAGE_PROFILE
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class SignUpProfileActivity :
@@ -19,6 +24,7 @@ class SignUpProfileActivity :
         initMyPageProfileAppBarTitle()
         initUpdateErrorMessage()
         initDoubleBtnClickListener()
+        initMyPageStateObserve()
     }
 
     private fun initMyPageProfileAppBarTitle() {
@@ -40,13 +46,34 @@ class SignUpProfileActivity :
 
     private fun initDoubleBtnClickListener() {
         binding.btnSignUpProfileDoubleCheck.setOnClickListener {
-            val doubleCheckFlag = viewModel.isBtnSelected.value
-            val messageResId =
-                if (doubleCheckFlag == true) R.string.sign_up_profile_use_posssible else R.string.sign_up_profile_use_impossible
-            val textColorResId = if (doubleCheckFlag == true) R.color.primary else R.color.error
-
-            updateAgreeMessage(messageResId, textColorResId)
+            viewModel.getNickNameDoubleCheck(binding.etSignUpProfileNickname.text.toString())
         }
+    }
+
+    private fun updateErrorMessage(doubleCheck: Boolean) {
+        val messageResId =
+            if (doubleCheck) R.string.sign_up_profile_use_posssible else R.string.sign_up_profile_use_impossible
+        val textColorResId = if (doubleCheck) R.color.primary else R.color.error
+
+        updateAgreeMessage(messageResId, textColorResId)
+    }
+
+    private fun initMyPageStateObserve() {
+        viewModel.nickNameDoubleState.flowWithLifecycle(lifecycle).onEach {
+            when (it) {
+                is UiState.Loading -> Unit
+                is UiState.Success -> {
+                    if (it.data.isEmpty()) {
+                        updateErrorMessage(false)
+                    } else {
+                        updateErrorMessage(true)
+                    }
+                }
+
+                is UiState.Empty -> Unit
+                is UiState.Failure -> Unit
+            }
+        }.launchIn(lifecycleScope)
     }
 
     private fun updateAgreeMessage(messageResId: Int, textColorResId: Int) {

--- a/feature/src/main/java/com/teamdontbe/feature/signup/SignUpProfileViewModel.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/signup/SignUpProfileViewModel.kt
@@ -3,12 +3,21 @@ package com.teamdontbe.feature.signup
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teamdontbe.core_ui.view.UiState
+import com.teamdontbe.domain.repository.LoginRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class SignUpProfileViewModel : ViewModel() {
+@HiltViewModel
+class SignUpProfileViewModel
+@Inject constructor(private val loginRepository: LoginRepository) : ViewModel() {
     private var _isBtnSelected = MutableLiveData<Boolean>(false)
     val isBtnSelected: LiveData<Boolean> get() = _isBtnSelected
-
-    private val testNick = "aaa"
 
     private var _isNickNameValid = MutableLiveData<Boolean>()
     val isNickNameValid: LiveData<Boolean> get() = _isNickNameValid
@@ -18,6 +27,22 @@ class SignUpProfileViewModel : ViewModel() {
 
     private var _introduceNum = MutableLiveData<String>()
     val introduceNum = _introduceNum
+
+    private val _nickNameDoubleState = MutableStateFlow<UiState<String>>(UiState.Empty)
+    val nickNameDoubleState: StateFlow<UiState<String>> = _nickNameDoubleState
+
+    private var flag = false
+
+    fun getNickNameDoubleCheck(nickName: String) {
+        viewModelScope.launch {
+            loginRepository.getNickNameDoubleCheck(nickName).collectLatest {
+                _nickNameDoubleState.value = UiState.Success(it)
+                flag = it.isEmpty()
+                updateNextNameBtnValidity()
+            }
+            _nickNameDoubleState.value = UiState.Empty
+        }
+    }
 
     fun setNickName(input: String) {
         this._nickName.value = input
@@ -34,7 +59,7 @@ class SignUpProfileViewModel : ViewModel() {
     }
 
     private fun updateNextNameBtnValidity() {
-        _isBtnSelected.value = (testNick != _nickName.value && _isNickNameValid.value == true)
+        _isBtnSelected.value = (!flag && _isNickNameValid.value == true)
     }
 
     companion object {


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #107

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 닉네임 중복체크 서버 통신
- 

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/TeamDon-tBe/ANDROID/assets/106955456/dc8b5a31-4517-4e46-9fae-5817a3661105


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
일단은 로그인 레포 쪽에 코드를 작성햇는데 맞는 지는 모르겠네요. 추후에 회원가입 흐름이 어떻게 흐를지 얘기 해봐야할 것 같습니다! 머리가 멈췄네요 지금