### PR TITLE
[Hotfix/#190] : fix kakologin

### DIFF
--- a/feature/src/main/AndroidManifest.xml
+++ b/feature/src/main/AndroidManifest.xml
@@ -15,6 +15,25 @@
         android:theme="@style/Theme.DontBe"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="${kakaoApiKey}" />
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="oauth"
+                    android:scheme="kakao${kakaoApiKey}"
+                    tools:ignore="AppLinkUrlError" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".SplashActivity"
             android:exported="true"

--- a/feature/src/main/java/com/teamdontbe/feature/login/LoginActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/login/LoginActivity.kt
@@ -45,6 +45,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         } else if (token != null) {
             Timber.i(ContentValues.TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
             loginViewModel.saveAccessToken(token.accessToken)
+            loginViewModel.postLogin("KAKAO")
         }
     }
 
@@ -76,8 +77,6 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                                 Timber.tag("kakao").i("카카오톡으로 로그인 성공 %s", token.accessToken)
                                 loginViewModel.saveAccessToken(token.accessToken)
                                 loginViewModel.postLogin("KAKAO")
-                                loginViewModel.saveCheckLogin(true)
-                                navigateToMainActivity()
                             }
                         }
                     }
@@ -101,6 +100,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
                         it.data.memberProfileUrl,
                         it.data.isNewUser,
                     )
+                    loginViewModel.saveCheckLogin(true)
                     navigateToMainActivity()
                 }
 


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #190 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- manifest에 누락된 kakao api key 추가
- 카카오 앱 키 : 네이티브 키로 등록 (각자 해야 됨)
- 카카오 로그인 완료 후 앱 진입 -> 돈비 로그인 완료 후 앱 진입으로 로직 변경

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/TeamDon-tBe/ANDROID/assets/98076050/55fd755e-9f54-45d0-b35c-d756a1ccc3b1

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 진챠... 릴리스 모드에서 안되는거 릴리스 해시키 등록 안해서 그런거 맞았음!!! 추가하니까 드디어어억 된다
- 네이티브 키 한번 다시 재발급해서 톡방에 보냈으니 로컬프로퍼티에 추가해주세요!
- 참고로 카톡 동의화면 창은 원래 한번만 뜨는거라고 합니다. 한번 동의하면 2번째부터 안뜸! 
- 동의화면 창 보고 싶으면 https://devtalk.kakao.com/t/topic/116096/3 이거 참고해서 동의 해제 누르면 됨!