### PR TITLE
[Feature/#210] 로딩뷰 초 설정 및 애니메이션 적용

### DIFF
--- a/feature/src/main/AndroidManifest.xml
+++ b/feature/src/main/AndroidManifest.xml
@@ -80,6 +80,7 @@
         <activity
             android:name=".LoadingActivity"
             android:exported="false"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:theme="@style/NoAnimationTheme" />
     </application>
 </manifest>

--- a/feature/src/main/java/com/teamdontbe/feature/LoadingActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/LoadingActivity.kt
@@ -1,12 +1,39 @@
 package com.teamdontbe.feature
 
+import android.os.Handler
+import android.view.View
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
 import com.teamdontbe.core_ui.base.BindingActivity
 import com.teamdontbe.feature.databinding.ActivityLoadingBinding
 import kotlin.random.Random
 
 class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activity_loading) {
+
+    lateinit var fadeOutAnim: Animation
+
     override fun initView() {
         initLoadingContent()
+
+        initAnimation()
+    }
+
+    private fun initAnimation() {
+        Handler().postDelayed({
+            fadeOutAnim = AnimationUtils.loadAnimation(this, R.anim.anim_loading_fade_out)
+            fadeOutAnim.setAnimationListener(object : Animation.AnimationListener {
+                override fun onAnimationStart(animation: Animation?) {}
+
+                override fun onAnimationEnd(animation: Animation?) {
+                    // 애니메이션이 끝난 후에 액티비티를 종료
+                    binding.layoutLoading.visibility = View.GONE
+                    finish()
+                }
+
+                override fun onAnimationRepeat(animation: Animation?) {}
+            })
+            binding.layoutLoading.startAnimation(fadeOutAnim)
+        }, 1800)
     }
 
     private fun initLoadingContent() {

--- a/feature/src/main/java/com/teamdontbe/feature/LoadingActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/LoadingActivity.kt
@@ -1,11 +1,13 @@
 package com.teamdontbe.feature
 
-import android.os.Handler
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.lifecycle.lifecycleScope
 import com.teamdontbe.core_ui.base.BindingActivity
 import com.teamdontbe.feature.databinding.ActivityLoadingBinding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activity_loading) {
@@ -19,8 +21,10 @@ class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activit
     }
 
     private fun initAnimation() {
-        Handler().postDelayed({
-            fadeOutAnim = AnimationUtils.loadAnimation(this, R.anim.anim_loading_fade_out)
+        lifecycleScope.launch {
+            delay(1800)
+            fadeOutAnim =
+                AnimationUtils.loadAnimation(this@LoadingActivity, R.anim.anim_loading_fade_out)
             fadeOutAnim.setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationStart(animation: Animation?) {}
 
@@ -33,7 +37,7 @@ class LoadingActivity : BindingActivity<ActivityLoadingBinding>(R.layout.activit
                 override fun onAnimationRepeat(animation: Animation?) {}
             })
             binding.layoutLoading.startAnimation(fadeOutAnim)
-        }, 1800)
+        }
     }
 
     private fun initLoadingContent() {

--- a/feature/src/main/res/anim/anim_loading_fade_out.xml
+++ b/feature/src/main/res/anim/anim_loading_fade_out.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_longAnimTime"
+    android:fromAlpha="1.0"
+    android:interpolator="@android:anim/accelerate_interpolator"
+    android:toAlpha="0.0" />

--- a/feature/src/main/res/layout/activity_loading.xml
+++ b/feature/src/main/res/layout/activity_loading.xml
@@ -8,6 +8,7 @@
     </data>
 
     <LinearLayout
+        android:id="@+id/layout_loading"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center_horizontal"

--- a/feature/src/main/res/values/themes.xml
+++ b/feature/src/main/res/values/themes.xml
@@ -31,4 +31,8 @@
         <item name="android:textSelectHandleLeft">@drawable/shape_primary_fill_left10_rect</item>
         <item name="android:textSelectHandleRight">@drawable/shape_primary_fill_right10_rect</item>
     </style>
+
+    <style name="NoAnimationTheme" parent="Theme.DontBe">
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
 </resources>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #210

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 로딩뷰 초 설정 및 페이드 아웃 처리

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
https://github.com/TeamDon-tBe/ANDROID/assets/85453429/cbbc8722-32d0-4704-abc9-917b8e5c8309

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
animation 끝나고 finish 설정하면 끝나고 loading activity가 한번 더 뜨고.. 반대로 하면 animation 시작되기 전에 finish 돼버리고...
생명주기 웅앵 공부하다가 뒤늦게 해당 뷰를 visibility.GONE 하면 된다는걸 뉘우쳤을 때의 허탈함..

activity와 fragment에 기본 애니메이션이 있다는 것도 알게되었읍니다 ^__^

영상은 테스트하기 위해 노티에 연결한겁니다