### PR TITLE
[#228/FIIX] : bottom navi 이슈 해결

### DIFF
--- a/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
@@ -92,7 +92,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
         initBottomNavPostingClickListener(navController)
         selectedHomeIcon(navController)
-        initLoadingView(navController)
+        setOnBottomNaviSelectedListener(navController)
         setOnBottomNaviReselectedListener(navController)
     }
 
@@ -135,7 +135,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private fun selectedHomeIcon(navController: NavController) {
         navController.addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
-                R.id.fragment_home, R.id.fragment_home_detail -> {
+                R.id.fragment_home_detail -> {
                     binding.bnvMain.menu.findItem(R.id.fragment_home).isChecked = true
                 }
 
@@ -146,15 +146,12 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         }
     }
 
-    private fun initLoadingView(navController: NavController) {
+    private fun setOnBottomNaviSelectedListener(navController: NavController) {
         binding.bnvMain.setOnItemSelectedListener { item ->
-            if (item.itemId == R.id.fragment_home) {
-                startActivity(
-                    Intent(
-                        this,
-                        LoadingActivity::class.java
-                    )
-                )
+            when (item.itemId) {
+                R.id.fragment_home -> startActivity(Intent(this, LoadingActivity::class.java))
+                R.id.fragment_my_page -> if (navController.currentDestination?.id == R.id.fragment_home_detail) navController.popBackStack()
+                R.id.fragment_notification -> if (navController.currentDestination?.id == R.id.fragment_home_detail) navController.popBackStack()
             }
             item.onNavDestinationSelected(navController)
         }

--- a/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
@@ -150,7 +150,12 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         binding.bnvMain.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.fragment_home -> startActivity(Intent(this, LoadingActivity::class.java))
-                R.id.fragment_my_page -> if (navController.currentDestination?.id == R.id.fragment_home_detail) navController.popBackStack()
+                //my page는 타 유저 프로필 피드 들어갈 때도 있어서
+                R.id.fragment_my_page -> if (navController.currentDestination?.id == R.id.fragment_home_detail) {
+                    navController.navigate(R.id.fragment_my_page)
+                    navController.popBackStack(R.id.fragment_home_detail, true)
+                }
+
                 R.id.fragment_notification -> if (navController.currentDestination?.id == R.id.fragment_home_detail) navController.popBackStack()
             }
             item.onNavDestinationSelected(navController)


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #228 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 각 mypage, noti에서 homedetail로 넘어갔을 때 bottomnavigation 안눌리는 이슈 해결했습니다.

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/TeamDon-tBe/ANDROID/assets/98076050/4922b09b-1ca2-4432-89f4-2a4c90476da9


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
