### PR TITLE
[Feature/#230] : home detail api v2

### DIFF
--- a/data-remote/src/main/java/com/teamdontbe/data_remote/api/HomeApiService.kt
+++ b/data-remote/src/main/java/com/teamdontbe/data_remote/api/HomeApiService.kt
@@ -29,6 +29,7 @@ interface HomeApiService {
         const val UNLIKED = "unliked"
         const val COMMENT_ID = "commentId"
         const val GHOST = "ghost2"
+        const val V2 = "v2"
     }
 
     @GET("$API/$V1/$CONTENTS")
@@ -36,7 +37,7 @@ interface HomeApiService {
         @Query(value = CURSOR) contentId: Long = -1,
     ): BaseResponse<List<ResponseFeedDto>>
 
-    @GET("/$API/$V1/$CONTENT/{$CONTENT_ID}/$DETAIL")
+    @GET("/$API/$V2/$CONTENT/{$CONTENT_ID}/$DETAIL")
     suspend fun getFeedDetail(
         @Path(value = CONTENT_ID) contentId: Int,
     ): BaseResponse<ResponseFeedDto>

--- a/feature/src/main/java/com/teamdontbe/feature/homedetail/HomeDetailFragment.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/homedetail/HomeDetailFragment.kt
@@ -247,7 +247,7 @@ class HomeDetailFragment :
         homeViewModel.getFeedDetail.flowWithLifecycle(viewLifeCycle).onEach { result ->
             when (result) {
                 is UiState.Success -> {
-                    initHomeFeedAdapter(listOf(result.data))
+                    initHomeFeedAdapter(listOf(result.data.copy(contentId = contentId)))
                     binding.feed = result.data
                     concatFeedCommentAdapter()
                 }

--- a/feature/src/main/res/navigation/nav_main.xml
+++ b/feature/src/main/res/navigation/nav_main.xml
@@ -37,7 +37,9 @@
             app:enterAnim="@anim/anim_posting_fragment_from_right"
             app:exitAnim="@anim/anim_posting_fragment_to_left"
             app:popEnterAnim="@anim/anim_posting_fragment_from_right"
-            app:popExitAnim="@anim/anim_posting_fragment_to_right" />
+            app:popExitAnim="@anim/anim_posting_fragment_to_right"
+            app:popUpTo="@id/fragment_home"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/fragment_notification"

--- a/feature/src/main/res/navigation/nav_main.xml
+++ b/feature/src/main/res/navigation/nav_main.xml
@@ -67,9 +67,7 @@
         tools:layout="@layout/fragment_my_page">
         <action
             android:id="@+id/action_fragment_my_page_to_fragment_home_detail"
-            app:destination="@id/fragment_home_detail"
-            app:popUpTo="@id/fragment_home_detail"
-            app:popUpToInclusive="false" />
+            app:destination="@id/fragment_home_detail" />
         <action
             android:id="@+id/action_fragment_my_page_to_fragment_posting"
             app:destination="@id/fragment_posting"
@@ -114,8 +112,6 @@
         tools:layout="@layout/fragment_home_detail">
         <action
             android:id="@+id/action_fragment_home_detail_to_fragment_my_page"
-            app:destination="@id/fragment_my_page"
-            app:popUpTo="@id/fragment_my_page"
-            app:popUpToInclusive="true" />
+            app:destination="@id/fragment_my_page" />
     </fragment>
 </navigation>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #230 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
-  변경된 홈 상세 api 반영했습니다.
- posting -> home 이동할 때 백스택 지우도록 수정했습니다. (인스타, 스레드 모두 이 방식이더라구요)
- home, home detail -> 타 유저 프로필 -> home~ -> 타 유저 프로필 이런 식의 순환 구조일 때 기존에는 쌓이는 스택들을 지워버리는 방식을 사용했습니다. 스레드랑 인스타를 참고하니깐 순환 구조일 때도 백스택으로 남겨두더군요?! 대기업을 따라가야죠 ㅋ.ㅋ 스택 모두 남기는 방식으로 수정했습니다

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
### posting -> home 뒤로가기
| 기존 | 수정 |
|--------|--------|
| <img src="https://github.com/TeamDon-tBe/ANDROID/assets/98076050/1c3ed80d-ce09-4d93-b855-dbc67b622870" alt="기존" width="200"> | <img src="https://github.com/TeamDon-tBe/ANDROID/assets/98076050/829368ff-b646-44a1-88ad-fe5b848f96ad" alt="수정" width="200">  | 

### home -> 마이페이지 순환 구조일 때 뒤로가기

https://github.com/TeamDon-tBe/ANDROID/assets/98076050/84bb2883-c5a8-4fb8-9446-eb92046cd99d


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
