### PR TITLE
[Hotfix/#235] api레벨에 따라 포토피커/갤러리 퍼미션 수정

### DIFF
--- a/feature/src/main/java/com/teamdontbe/feature/signup/SignUpProfileActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/signup/SignUpProfileActivity.kt
@@ -115,9 +115,12 @@ class SignUpProfileActivity :
         initImagePlusBtnClickListener()
     }
 
-    private fun initImagePlusBtnClickListener() {
-        binding.btnSignUpProfilePlus.setOnClickListener {
+    private fun initImagePlusBtnClickListener() = with(binding) {
+        btnSignUpProfilePlus.setOnClickListener {
             // 갤러리 이미지 가져오기
+            getGalleryPermission()
+        }
+        ivSignUpProfile.setOnClickListener {
             getGalleryPermission()
         }
     }

--- a/feature/src/main/res/layout/activity_sign_up_agree.xml
+++ b/feature/src/main/res/layout/activity_sign_up_agree.xml
@@ -21,13 +21,22 @@
             android:orientation="vertical"
             app:layout_constraintGuide_begin="23dp" />
 
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guide_sign_up_end_23"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="23dp" />
+
         <TextView
             android:id="@+id/tv_sign_up_agree"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="46dp"
             android:text="@string/sign_up_agree_title"
+            android:textAlignment="textStart"
             android:textAppearance="@style/TextAppearance.DontBe.head_semi_20"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toStartOf="@id/guide_sign_up_start_23"
             app:layout_constraintTop_toBottomOf="@id/appbar_sign_up" />
 
@@ -37,8 +46,10 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:text="@string/sign_up_agree_description"
+            android:textAlignment="textStart"
             android:textAppearance="@style/TextAppearance.DontBe.body_regular_16"
             android:textColor="@color/gray_9"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toStartOf="@id/guide_sign_up_start_23"
             app:layout_constraintTop_toBottomOf="@id/tv_sign_up_agree" />
 
@@ -68,9 +79,11 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="11dp"
             android:text="@string/sign_up_agree_choose_all"
+            android:textAlignment="textStart"
             android:textAppearance="@style/TextAppearance.DontBe.body_semi_16"
             android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="@id/cb_sign_up_parent"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toEndOf="@id/cb_sign_up_parent"
             app:layout_constraintTop_toTopOf="@id/cb_sign_up_parent" />
 
@@ -82,36 +95,24 @@
             android:background="@drawable/sel_sign_up_checkbox"
             android:button="@null"
             app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toStartOf="@id/tv_sign_up_child_1"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="@id/guide_sign_up_start_23"
             app:layout_constraintTop_toBottomOf="@id/cb_sign_up_parent" />
 
         <TextView
             android:id="@+id/tv_sign_up_child_1"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="11dp"
             android:text="@string/sign_up_agree_child_1"
             android:textAppearance="@style/TextAppearance.DontBe.body_regular_16"
             android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="@id/cb_sign_up_child_1"
+            app:layout_constraintEnd_toStartOf="@id/mcv_sign_up_agree_green_child_1"
             app:layout_constraintStart_toEndOf="@id/cb_sign_up_child_1"
             app:layout_constraintTop_toTopOf="@id/cb_sign_up_child_1" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:background="@drawable/shape_6_rect"
-            android:backgroundTint="#59CD9C"
-            android:gravity="center"
-            android:paddingHorizontal="6dp"
-            android:paddingTop="2dp"
-            android:text="@string/sign_up_agree_must"
-            android:textAppearance="@style/TextAppearance.DontBe.cap_regular_12"
-            android:textColor="@color/black"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/tv_sign_up_child_1"
-            app:layout_constraintStart_toEndOf="@id/tv_sign_up_child_1"
-            app:layout_constraintTop_toTopOf="@id/tv_sign_up_child_1" />
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/mcv_sign_up_agree_green_child_1"
@@ -121,6 +122,7 @@
             app:cardBackgroundColor="#59CD9C"
             app:cardCornerRadius="6dp"
             app:layout_constraintBottom_toBottomOf="@id/tv_sign_up_child_1"
+            app:layout_constraintEnd_toStartOf="@id/btn_sign_up_agree_child_1"
             app:layout_constraintStart_toEndOf="@id/tv_sign_up_child_1"
             app:layout_constraintTop_toTopOf="@id/tv_sign_up_child_1"
             app:strokeWidth="0dp">
@@ -148,6 +150,7 @@
             android:src="@drawable/ic_sign_up_next_gray_24"
             app:layout_constraintBottom_toBottomOf="@id/mcv_sign_up_agree_green_child_1"
             app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toEndOf="@id/mcv_sign_up_agree_green_child_1"
             app:layout_constraintTop_toTopOf="@id/mcv_sign_up_agree_green_child_1" />
 
@@ -160,18 +163,22 @@
             android:background="@drawable/sel_sign_up_checkbox"
             android:button="@null"
             app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toStartOf="@id/tv_sign_up_child_2"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="@id/guide_sign_up_start_23"
             app:layout_constraintTop_toBottomOf="@id/cb_sign_up_child_1" />
 
         <TextView
             android:id="@+id/tv_sign_up_child_2"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="11dp"
             android:text="@string/sign_up_agree_child_2"
             android:textAppearance="@style/TextAppearance.DontBe.body_regular_16"
             android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="@id/cb_sign_up_child_2"
+            app:layout_constraintEnd_toStartOf="@id/mcv_sign_up_agree_green_child_2"
             app:layout_constraintStart_toEndOf="@id/cb_sign_up_child_2"
             app:layout_constraintTop_toTopOf="@id/cb_sign_up_child_2" />
 
@@ -183,6 +190,7 @@
             app:cardBackgroundColor="#59CD9C"
             app:cardCornerRadius="6dp"
             app:layout_constraintBottom_toBottomOf="@id/tv_sign_up_child_2"
+            app:layout_constraintEnd_toStartOf="@id/btn_sign_up_agree_child_2"
             app:layout_constraintStart_toEndOf="@id/tv_sign_up_child_2"
             app:layout_constraintTop_toTopOf="@id/tv_sign_up_child_2"
             app:strokeWidth="0dp">
@@ -210,6 +218,7 @@
             android:src="@drawable/ic_sign_up_next_gray_24"
             app:layout_constraintBottom_toBottomOf="@id/mcv_sign_up_agree_green_child_2"
             app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toEndOf="@id/mcv_sign_up_agree_green_child_2"
             app:layout_constraintTop_toTopOf="@id/mcv_sign_up_agree_green_child_2" />
 
@@ -221,18 +230,22 @@
             android:background="@drawable/sel_sign_up_checkbox"
             android:button="@null"
             app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toStartOf="@id/tv_sign_up_child_3"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="@id/guide_sign_up_start_23"
             app:layout_constraintTop_toBottomOf="@id/cb_sign_up_child_2" />
 
         <TextView
             android:id="@+id/tv_sign_up_child_3"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="11dp"
             android:text="@string/sign_up_agree_child_3"
             android:textAppearance="@style/TextAppearance.DontBe.body_regular_16"
             android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="@id/cb_sign_up_child_3"
+            app:layout_constraintEnd_toStartOf="@id/mcv_sign_up_agree_green_child_3"
             app:layout_constraintStart_toEndOf="@id/cb_sign_up_child_3"
             app:layout_constraintTop_toTopOf="@id/cb_sign_up_child_3" />
 
@@ -244,6 +257,7 @@
             app:cardBackgroundColor="@color/sign_up_green_must"
             app:cardCornerRadius="6dp"
             app:layout_constraintBottom_toBottomOf="@id/tv_sign_up_child_3"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toEndOf="@id/tv_sign_up_child_3"
             app:layout_constraintTop_toTopOf="@id/tv_sign_up_child_3"
             app:strokeWidth="0dp">
@@ -272,6 +286,7 @@
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/mcv_sign_up_agree_green_child_3"
             app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toEndOf="@id/mcv_sign_up_agree_green_child_3"
             app:layout_constraintTop_toTopOf="@id/mcv_sign_up_agree_green_child_3" />
 
@@ -336,14 +351,13 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
-            android:layout_marginEnd="23dp"
             android:background="?attr/selectableItemBackground"
             android:clickable="true"
             android:focusable="true"
             android:src="@drawable/ic_sign_up_next_gray_24"
             app:layout_constraintBottom_toBottomOf="@id/mcv_sign_up_agree_green_child_4"
             app:layout_constraintDimensionRatio="1"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guide_sign_up_end_23"
             app:layout_constraintStart_toEndOf="@id/mcv_sign_up_agree_green_child_4"
             app:layout_constraintTop_toTopOf="@id/mcv_sign_up_agree_green_child_4" />
 

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -76,6 +76,11 @@
     <string name="sign_up_profile_one_introduce">한 줄 소개</string>
     <string name="sign_up_profile_description">한 줄로 자신을 소개해주세요.</string>
     <string name="sign_up_profile_completed">완료하기</string>
+    <string name="sign_up_profile_permission_title">권한이 필요해요</string>
+    <string name="sign_up_profile_permission_description">이 앱은 갤러리 접근 권한이 필요해요.\n앱 세팅으로 이동해서 권한을 부여 할 수 있어요.</string>
+    <string name="sign_up_profile_permission_move">이동하기</string>
+    <string name="sign_up_profile_permission_cancle">취소하기</string>
+
     <!-- 홈 화면 -->
     <string name="tv_home_detail_appbar_title">게시글</string>
     <string name="et_home_detail_input">don\'t be master님에게 답글 남기기</string>


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #235 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- api 34이상의 경우 권한 없이 바로 포토피커가 실행되도록 하였습니다. 추후 api34이상 포토피커의 이미지마다 사용자가 allow를 할 수 있는데 이 부분 확인해서 수정 하겠습니다. 현재는 바로 실행됩니다.
- api 33의 경우 포토피커를 실행하지만 권한 거부 시에 외부 앱 세팅으로 이동하여 권한을 allow하도록 코드를 수정 하였습니다. 한번 사용자가 권한 거부 후 앱/화면을 나갔을 시에는 버튼을 다시 눌러도 앱 내에서 권한 모달이 더이상 나타나지 않는다 합니다.
- 그 이하의 경우 갤러리를 실행시키도록 코드를 수정하였습니다.

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<img src = "https://github.com/TeamDon-tBe/ANDROID/assets/106955456/70f99b18-c281-40bf-8c21-8144d509534e" width=35%/>


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
api 34의 경우 추후 수정하여 올리겠습니다. api34이상 포토피커의 경우 퍼미션이 아에 필요 없다는 정보들도 있고(작년 세미나 자료), 퍼미션이 필요 하다는 정보들도 있어서 혼동 되네요.