### PR TITLE
#242 [fix] : 바텀 내비 select + scroll 안되는 오류 수정

### DIFF
--- a/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/MainActivity.kt
@@ -93,7 +93,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         initBottomNavPostingClickListener(navController)
         selectedHomeIcon(navController)
         setOnBottomNaviSelectedListener(navController)
-        setOnBottomNaviReselectedListener(navController)
+//        setOnBottomNaviReselectedListener(navController)
     }
 
     private fun removeBadgeOnNotification(navController: NavController) {
@@ -150,7 +150,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         binding.bnvMain.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.fragment_home -> startActivity(Intent(this, LoadingActivity::class.java))
-                //my page는 타 유저 프로필 피드 들어갈 때도 있어서
+                // my page는 타 유저 프로필 피드 들어갈 때도 있어서
                 R.id.fragment_my_page -> if (navController.currentDestination?.id == R.id.fragment_home_detail) {
                     navController.navigate(R.id.fragment_my_page)
                     navController.popBackStack(R.id.fragment_home_detail, true)

--- a/feature/src/main/java/com/teamdontbe/feature/home/HomeFragment.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/home/HomeFragment.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.teamdontbe.core_ui.base.BindingFragment
+import com.teamdontbe.core_ui.util.fragment.setScrollTopOnReselect
 import com.teamdontbe.core_ui.util.fragment.statusBarColorOf
 import com.teamdontbe.core_ui.util.fragment.viewLifeCycle
 import com.teamdontbe.core_ui.util.fragment.viewLifeCycleScope
@@ -29,7 +30,6 @@ import com.teamdontbe.feature.util.pagingSubmitData
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import timber.log.Timber
 
 @AndroidEntryPoint
 class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home) {
@@ -224,9 +224,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     fun scrollRecyclerViewToTop() {
-        binding.rvHome.post {
-            binding.rvHome.smoothScrollToPosition(0)
-        }
+        setScrollTopOnReselect(R.id.fragment_home, R.id.bnv_main, binding.rvHome)
     }
 
     companion object {

--- a/feature/src/main/java/com/teamdontbe/feature/homedetail/HomeDetailFragment.kt
+++ b/feature/src/main/java/com/teamdontbe/feature/homedetail/HomeDetailFragment.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.ConcatAdapter
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.teamdontbe.core_ui.base.BindingFragment
 import com.teamdontbe.core_ui.util.context.hideKeyboard
 import com.teamdontbe.core_ui.util.fragment.statusBarColorOf
@@ -62,6 +63,7 @@ class HomeDetailFragment :
         observePostCommentPosting()
         initBackBtnClickListener()
         initInputEditTextClickListener()
+        initClickHomeBottomIcon()
     }
 
     private fun getHomeDetail() {
@@ -361,6 +363,17 @@ class HomeDetailFragment :
             parentFragmentManager,
             COMMENT,
         )
+    }
+
+    private fun initClickHomeBottomIcon() {
+        val mainActivity = requireActivity() as? MainActivity
+
+        mainActivity?.findViewById<BottomNavigationView>(R.id.bnv_main)
+            ?.setOnItemReselectedListener { item ->
+                if (item.itemId == R.id.fragment_home) {
+                    findNavController().popBackStack()
+                }
+            }
     }
 
     companion object {


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #242 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 홈 <-> 마이페이지 이동후 scroll to top안되는 오류 수정
- 홈 -> 홈디테일 에서 이동후 홈화면 바텀 아이콘 클릭시 홈으로 가게 수정

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
홈 -> 홈디테일 -> 마이페이지 (스크롤 to top) -> [백버튼]>> 홈 (스크롤 to top)

https://github.com/TeamDon-tBe/ANDROID/assets/106955456/4e4f05ae-7154-48b7-b422-095f3643e2ac


홈 -> 홈디테일 -> [홈탭클릭]>> 홈 (스크롤 to top)

https://github.com/TeamDon-tBe/ANDROID/assets/106955456/8a68b314-83f1-4e49-aecd-e1185d693c00



## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
페이지 이동하면서 스택이 약간 이상한 부분은 있네요
홈 디테일 -> 마이페이지 여기서 백버튼 누르면 홈화면으로 가기는 합니다.

현재 코드의 문제점 마이페이지-> 홈 디테일 -> [홈탭클릭] -> 마이페이지
홈디테일에서 홈탭을 클릭할시에 popBackStack을 실행시켜야 해서 생기는 문제인 것 같습니다!